### PR TITLE
Use the mining icon to highlight the leader

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -634,7 +634,7 @@ Node.prototype.getStats = function(forced)
 				});
 			},
 			leaders: function (callback) {
-				if (self.stats.currentView % 10 === 0) {
+				if (self.stats.currentView % PREFETCHED_LEADERS === 0) {
 					const payload = {
 						jsonrpc: "2.0",
 						method: "admin_getLeaders",

--- a/lib/node.js
+++ b/lib/node.js
@@ -23,6 +23,8 @@ var ETH_VERSION,
 	COINBASE;
 
 var INSTANCE_NAME = process.env.INSTANCE_NAME;
+var PEER_ID = process.env.PEER_ID;
+var PREFETCHED_LEADERS = 10;
 var WS_SECRET = process.env.WS_SECRET || "eth-net-stats-has-a-secret";
 
 var PENDING_WORKS = true;
@@ -86,7 +88,7 @@ function Node ()
 		port: (process.env.LISTENING_PORT || 3333),
 		os: os.platform(),
 		os_v: os.release(),
-		client: pjson.version,
+		client: PEER_ID || "non-validator", //pjson.version,
 		canUpdateHistory: true,
 	};
 
@@ -144,6 +146,8 @@ function Node ()
 	this._chain_debouncer_cnt = 0;
 	this._connection_attempts = 0;
 	this._timeOffset = null;
+
+	this.leaders = [];
 
 	this.startWeb3Connection();
 
@@ -628,6 +632,26 @@ Node.prototype.getStats = function(forced)
 						callback(parseErr);
 					}
 				});
+			},
+			leaders: function (callback) {
+				if (self.stats.currentView % 10 === 0) {
+					const payload = {
+						jsonrpc: "2.0",
+						method: "admin_getLeaders",
+						params: [self.stats.currentView, PREFETCHED_LEADERS - 1],
+						id: 1
+					};
+					web3.currentProvider.sendAsync(payload, function (err, response) {
+						if (err) return callback(err);
+						try {
+							const result = response.result;
+							callback(null, result.map(item => item[1].peer_id));
+						} catch (parseErr) {
+							callback(parseErr);
+						}
+					});
+				} else 
+					callback(null, []);
 			}
 		},
 		function (err, results)
@@ -647,6 +671,11 @@ Node.prototype.getStats = function(forced)
 
 			console.sstats('==>', 'Got getStats results in', chalk.reset.cyan(results.diff, 'ms'));
 
+			if (results.leaders.length === PREFETCHED_LEADERS) {
+				self.leaders = results.leaders;
+				console.log('Prefetched leaders:', self.leaders);
+			}
+
 			if(results.peers !== null)
 			{
 				self.stats.active = true;
@@ -654,7 +683,7 @@ Node.prototype.getStats = function(forced)
 				self.stats.currentView = results.consensusInfo?.currentView;
 				self.stats.nextViewChange = results.consensusInfo?.nextViewChange;
 				self.stats.highQcView = results.consensusInfo?.highQcView;
-				self.stats.mining = results.mining;
+				self.stats.mining = self.leaders[self.stats.currentView % PREFETCHED_LEADERS] === PEER_ID; //results.mining;
 				self.stats.gasPrice = results.gasPrice.toString(10);
 
 				if(results.syncing !== false) {


### PR DESCRIPTION
It's a handy feature that helps identify the current view's leader, especially if the view times out. The leader is identified based on the new `PEER_ID` environment variable of the zilstat agent container. The `PEER_ID` is also displayed in the tooltip of the nodes.